### PR TITLE
Replace disutils.version.LooseVersion with packaging.version.Version

### DIFF
--- a/basicsr/archs/arch_util.py
+++ b/basicsr/archs/arch_util.py
@@ -3,7 +3,7 @@ import math
 import torch
 import torchvision
 import warnings
-from distutils.version import LooseVersion
+from packaging.version import Version
 from itertools import repeat
 from torch import nn as nn
 from torch.nn import functional as F
@@ -228,7 +228,7 @@ class DCNv2Pack(ModulatedDeformConvPack):
             logger = get_root_logger()
             logger.warning(f'Offset abs mean is {offset_absmean}, larger than 50.')
 
-        if LooseVersion(torchvision.__version__) >= LooseVersion('0.9.0'):
+        if Version(torchvision.__version__) >= Version('0.9.0'):
             return torchvision.ops.deform_conv2d(x, offset, self.weight, self.bias, self.stride, self.padding,
                                                  self.dilation, mask)
         else:

--- a/basicsr/archs/arch_util.py
+++ b/basicsr/archs/arch_util.py
@@ -3,7 +3,12 @@ import math
 import torch
 import torchvision
 import warnings
-from packaging.version import Version
+import sys
+if sys.version_info >= (3, 12):
+    from packaging.version import Version
+    LooseVersion = Version
+else:
+    from distutils.version import LooseVersion
 from itertools import repeat
 from torch import nn as nn
 from torch.nn import functional as F
@@ -228,7 +233,7 @@ class DCNv2Pack(ModulatedDeformConvPack):
             logger = get_root_logger()
             logger.warning(f'Offset abs mean is {offset_absmean}, larger than 50.')
 
-        if Version(torchvision.__version__) >= Version('0.9.0'):
+        if LooseVersion(torchvision.__version__) >= LooseVersion('0.9.0'):
             return torchvision.ops.deform_conv2d(x, offset, self.weight, self.bias, self.stride, self.padding,
                                                  self.dilation, mask)
         else:

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,8 @@ git clone https://github.com/mav-rik/facerestore_cf.git
 
 If running the portable windows version of ComfyUI, run embedded_install.bat
 Windows users not running the portable version can run install.bat. Linux and mac users can run install.sh.
-If the install fails for whatever reason, you'll need to work out how to install opencv-python yourself (you'll get a cv2 not found error otherwise)
+If the install fails for whatever reason, you'll need to work out how to install opencv-python yourself (you'll get a cv2 not found error otherwise).
+If you are using Python3.12 or higher version, please use `requirements_312.txt`.
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ gdown # supports downloading the large file from Google Drive
 # cmake
 # dlib
 # conda install -c conda-forge dlib
+packaging

--- a/requirements_312.txt
+++ b/requirements_312.txt
@@ -18,3 +18,4 @@ gdown # supports downloading the large file from Google Drive
 # cmake
 # dlib
 # conda install -c conda-forge dlib
+requirements.txt

--- a/requirements_312.txt
+++ b/requirements_312.txt
@@ -18,4 +18,4 @@ gdown # supports downloading the large file from Google Drive
 # cmake
 # dlib
 # conda install -c conda-forge dlib
-requirements.txt
+packaging


### PR DESCRIPTION
The disutils has been removed in python3.12. The removal was decided in [PEP 632](https://peps.python.org/pep-0632/).
So, in order to be compatible with versions higher than 3.12, `disutils.version.LooseVersion` needs to be replaced with `packaging.version.Version`